### PR TITLE
[flake] Switch to compat-24.11 branch of birdsong

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
     },
     "birdsong": {
       "locked": {
-        "lastModified": 1730835703,
-        "narHash": "sha256-VQWyAU+Nyh2a7jQlbn4my5XBE/OgiYKSBfRpPy7GMwg=",
-        "ref": "main",
-        "rev": "ffe25bd95a49d6595edec6caa432703a48b7a8fd",
-        "revCount": 12,
+        "lastModified": 1731357158,
+        "narHash": "sha256-RTFqn8DTPXEvkrhMuOODv198z9a0H96mlg4lrc2dplQ=",
+        "ref": "compat-24.11",
+        "rev": "fa0f559d3b41d5fff49ef081f95830270b4662ae",
+        "revCount": 13,
         "type": "git",
         "url": "https://git.qenya.tel/qenya/birdsong"
       },
       "original": {
-        "ref": "main",
+        "ref": "compat-24.11",
         "type": "git",
         "url": "https://git.qenya.tel/qenya/birdsong"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
     };
 
     birdsong = {
-      url = "git+https://git.qenya.tel/qenya/birdsong?ref=main";
+      url = "git+https://git.qenya.tel/qenya/birdsong?ref=compat-24.11";
     };
 
     qenyaNixfiles = {


### PR DESCRIPTION
Resolves backwards-compatibility issues caused by https://github.com/NixOS/nixpkgs/pull/312472.

See https://git.qenya.tel/qenya/birdsong/commit/fa0f559d3b41d5fff49ef081f95830270b4662ae.