### PR TITLE
sys: Correct default for filesystem options

### DIFF
--- a/services/zfs-create.nix
+++ b/services/zfs-create.nix
@@ -25,8 +25,8 @@ let
       };
 
       mountOptions = lib.mkOption {
-        type = types.listOf types.str;
-        default = [ ];
+        type = types.nonEmptyListOf types.nonEmptyStr;
+        default = [ "defaults" ];
       };
 
       zfsPermissions.users = lib.mkOption {
@@ -190,7 +190,7 @@ in
       nixDatasets) ++ (map
       (
         (datasetValue: {
-          assertion = (datasetValue.mountOptions != [ ]) -> (isNixDataset datasetValue);
+          assertion = (datasetValue.mountOptions != [ "defaults" ]) -> (isNixDataset datasetValue);
           message = "mountOptions is only implemented for datasets with fixed mount points";
         })
       )


### PR DESCRIPTION
This value is passed through to `fileSystems.<name>.options` and then to fstab, whose format does not allow it to be blank. So, if not otherwise specified, it needs to have a nonempty default value.